### PR TITLE
add size_t to elementary types

### DIFF
--- a/serialize.h
+++ b/serialize.h
@@ -44,6 +44,8 @@ template <>
 struct IsElementary<int32_t> : std::true_type {};
 template <>
 struct IsElementary<int64_t> : std::true_type {};
+template <>
+struct IsElementary<std::size_t> : std::true_type {};
 
 template <typename T, typename dummy = void>
 struct Serializer;


### PR DESCRIPTION
without this I can't compile the table serialization in FALCONN in my system (osx) (for some reason `long unsigned int` does not match `uint64_t`)